### PR TITLE
Windows fix

### DIFF
--- a/synapse/envs/miniwob/environment.py
+++ b/synapse/envs/miniwob/environment.py
@@ -3,7 +3,7 @@ import os
 from synapse.envs.miniwob.instance import MiniWoBInstance
 
 MINIWOB_DIR = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), "html", "miniwob"
+    os.path.dirname(os.path.realpath(__file__)), "html", "miniwob/"
 )
 
 EXTRA_HTML_TASKS = [

--- a/synapse/envs/miniwob/instance.py
+++ b/synapse/envs/miniwob/instance.py
@@ -97,7 +97,7 @@ class MiniWoBInstance(Thread):
             self.task_width = self.FLIGHT_TASK_WIDTH
             self.task_height = self.FLIGHT_TASK_HEIGHT
         else:
-            self.url = urlparse.urljoin(base_url, "miniwob/{}.html".format(subdomain))
+            self.url = urlparse.urljoin(base_url, "{}.html".format(subdomain))
             self.window_width = self.WINDOW_WIDTH
             self.window_height = self.WINDOW_HEIGHT
             self.task_width = self.TASK_WIDTH
@@ -169,11 +169,12 @@ class MiniWoBInstance(Thread):
             options.add_argument(
                 f"window-size={self.window_width},{self.window_height}"
             )
-            options.add_argument(
-                "window-position={},{}".format(
-                    9000, 30 + self.index * (self.window_height + 30)
-                )
-            )
+            # commeting because this is not working on all the display sizes
+            # options.add_argument(
+            #     "window-position={},{}".format(
+            #         9000, 30 + self.index * (self.window_height + 30)
+            #     )
+            # )
         self.driver = webdriver.Chrome(options=options)
         self.driver.implicitly_wait(5)
 


### PR DESCRIPTION
fix #5 

Squash and merge.
tested in windows and macos.

1) Fix the window placement issue. now it works on any size of screens.
2) Fix the URL file path for miniwob. there is a bug in `urlparse.urljoin()` 

```
MINIWOB_DIR = os.path.join(
    os.path.dirname(os.path.realpath(__file__)), "html", "miniwob"
)
MINIWOB_DIR = 'Projects\Synapse\synapse\envs\miniwob\html\miniwob'
```
```
subdomain='book-flight'
self.url = urlparse.urljoin(base_url, "{}.html".format(subdomain))
self.url = 'Projects\Synapse\synapse\envs\miniwob\html\book-flight.html'
```
so the urljoin remove the last miniwob from the base_url. I add '\' to the end.